### PR TITLE
Map WASD keys to movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Drag proto_controller folder into the "addons" folder at the root of your Godot 
 
 ## License
 This repo is freely available under the CC0 license. For more info see LICENSE file.
+
+## Changelog
+- v1.1
+  - Programmatically add WASD key presses to ui_up, ui_left, ui_down, ui_right

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ This repo is freely available under the CC0 license. For more info see LICENSE f
 
 ## Changelog
 - v1.1
-  - Programmatically add WASD key presses to ui_up, ui_left, ui_down, ui_right
+  - Add "Wasd Keys" bool to Input Actions exported group with default false
+  - Programmatically add WASD key presses to ui_up, ui_left, ui_down, ui_right if wasd_keys is true

--- a/proto_controller/proto_controller.gd
+++ b/proto_controller/proto_controller.gd
@@ -43,6 +43,8 @@ extends CharacterBody3D
 @export var input_sprint : String = "sprint"
 ## Name of Input Action to toggle freefly mode.
 @export var input_freefly : String = "freefly"
+## Use WASD keys for movement.
+@export var wasd_keys : bool = false
 
 var mouse_captured : bool = false
 var look_rotation : Vector2
@@ -54,20 +56,21 @@ var freeflying : bool = false
 @onready var collider: CollisionShape3D = $Collider
 
 func _ready() -> void:
-	# Map WASD keys to movement actions to prevent needing to create project Input
-	# Mappings and editing script.
-	var key_map = {
-		"ui_up": KEY_W,
-		"ui_left": KEY_A,
-		"ui_down": KEY_S,
-		"ui_right": KEY_D,
-	}
-	for action in key_map.keys():
-		var event := InputEventKey.new()
-		event.physical_keycode = key_map[action]
-		# For Godot 3.x, use scancode instead:
-		##event.scancode = key_map[action]
-		InputMap.action_add_event(action, event)
+	if wasd_keys:
+		# Map WASD keys to movement actions to prevent needing to create project
+		# Input Mappings and editing script.
+		var key_map = {
+			"ui_up": KEY_W,
+			"ui_left": KEY_A,
+			"ui_down": KEY_S,
+			"ui_right": KEY_D,
+		}
+		for action in key_map.keys():
+			var event := InputEventKey.new()
+			event.physical_keycode = key_map[action]
+			# For Godot 3.x, use scancode instead:
+			##event.scancode = key_map[action]
+			InputMap.action_add_event(action, event)
 
 	check_input_mappings()
 	look_rotation.y = rotation.y

--- a/proto_controller/proto_controller.gd
+++ b/proto_controller/proto_controller.gd
@@ -1,4 +1,4 @@
-# ProtoController v1.0 by Brackeys
+# ProtoController v1.1 by Brackeys
 # CC0 License
 # Intended for rapid prototyping of first-person games.
 # Happy prototyping!
@@ -54,6 +54,21 @@ var freeflying : bool = false
 @onready var collider: CollisionShape3D = $Collider
 
 func _ready() -> void:
+	# Map WASD keys to movement actions to prevent needing to create project Input
+	# Mappings and editing script.
+	var key_map = {
+		"ui_up": KEY_W,
+		"ui_left": KEY_A,
+		"ui_down": KEY_S,
+		"ui_right": KEY_D,
+	}
+	for action in key_map.keys():
+		var event := InputEventKey.new()
+		event.physical_keycode = key_map[action]
+		# For Godot 3.x, use scancode instead:
+		##event.scancode = key_map[action]
+		InputMap.action_add_event(action, event)
+
 	check_input_mappings()
 	look_rotation.y = rotation.y
 	look_rotation.x = head.rotation.x


### PR DESCRIPTION
Programmatically map WASD keys to movement actions to prevent needing to create project Input Mappings and editing script.

- Increase version to v1.1
- Add Changelog section to README including v1.1 change